### PR TITLE
Fix for files with dots in filenames 

### DIFF
--- a/audiosprite.js
+++ b/audiosprite.js
@@ -272,7 +272,7 @@ function processFiles() {
         cb()
       }
 
-      var name = path.basename(file).replace(/\..+$/, '')
+      var name = path.basename(file).replace(/\.[a-zA-Z0-9]+$/, '')
       appendFile(name, tmp, tempFile, function(err) {
         if (rawparts != null ? rawparts.length : void 0) {
         async.forEachSeries(rawparts, function(ext, cb) {


### PR DESCRIPTION
I tried to use audiosprite on a bunch of files with filenames like `intro.aap.wav` and `intro.olif.wav`, which were all cut to `intro` in the json file.

I made the regular expression that determines the name of the file a bit less greedy. This fixed it for me.
