### PR TITLE
Add support for VBR MP3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ iOS, Windows Phone and some Android phones have very limited HTML5 audio support
 npm install -g audiosprite
 ```
 
+You can install `FFmpeg` and the `ogg` codecs on OSX using `brew`:
+
+```
+brew install ffmpeg --with-theora --with-libogg --with-libvorbis
+```
+
 #### Hints for Windows users
 
 - You need to install [Node.js](https://www.nodejs.org/)
@@ -38,6 +44,7 @@ info: Options:
   --gap, -g         Silence gap between sounds (in seconds).                     [default: 1]
   --minlength, -m   Minimum sound duration (in seconds).                         [default: 0]
   --bitrate, -b     Bit rate. Works for: ac3, mp3, mp4, m4a, ogg.                [default: 128]
+  --vbr, -v         VBR [0-9]. Works for: mp3. -1 disables VBR.                  [default: -1]
   --samplerate, -r  Sample rate.                                                 [default: 44100]
   --channels, -c    Number of channels (1=mono, 2=stereo).                       [default: 1]
   --rawparts, -p    Include raw slices(for Web Audio API) in specified formats.  [default: ""]

--- a/audiosprite.js
+++ b/audiosprite.js
@@ -61,6 +61,11 @@ var optimist = require('optimist')
   , 'default': 128
   , describe: 'Bit rate. Works for: ac3, mp3, mp4, m4a, ogg.'
   })
+  .options('vbr', {
+    alias: 'v'
+  , 'default': -1
+  , describe: 'VBR [0-9]. Works for: mp3. -1 disables VBR.'
+  })
   .options('samplerate', {
     alias: 'r'
   , 'default': 44100
@@ -97,6 +102,7 @@ var SAMPLE_RATE = parseInt(argv.samplerate, 10)
 var NUM_CHANNELS = parseInt(argv.channels, 10)
 var GAP_SECONDS = parseFloat(argv.gap)
 var MINIMUM_SOUND_LENGTH = parseFloat(argv.minlength)
+var VBR = parseInt(argv.vbr, 10)
 
 var loops = argv.loop ? [].concat(argv.loop) : []
 
@@ -281,10 +287,17 @@ function processFiles() {
     aiff: []
   , wav: []
   , ac3: ['-acodec', 'ac3', '-ab', BIT_RATE + 'k']
-  , mp3: ['-ar', SAMPLE_RATE, '-ab', BIT_RATE + 'k', '-f', 'mp3']
+  , mp3: ['-ar', SAMPLE_RATE, '-f', 'mp3']
   , mp4: ['-ab', BIT_RATE + 'k']
   , m4a: ['-ab', BIT_RATE + 'k']
   , ogg: ['-acodec', 'libvorbis', '-f', 'ogg', '-ab', BIT_RATE + 'k']
+  }
+
+  if (VBR >= 0 && VBR <= 9) {
+    formats.mp3 = formats.mp3.concat(['-aq', VBR])
+  }
+  else {
+    formats.mp3 = formats.mp3.concat(['-ab', BIT_RATE + 'k'])
   }
 
   if (argv.export.length) {


### PR DESCRIPTION
This adds support for VBR MP3 which produces much smaller files. The support in `mp4` is still experimental so I haven't added it.
FFmpeg docs: https://trac.ffmpeg.org/wiki/Encode/MP3

Granted the lines `296-302` aren't the sexiest but I didn't see any better way doing it quickly. Happy to change that if there's another place in the code I haven't seen.

Also, I've added a line about installing `ffmpeg` on OSX along with the ogg codecs. An error I ran into immediately.

Thanks for making such a useful module!
