### PR TITLE
Use complete custom path, rather than prepending it

### DIFF
--- a/audiosprite.js
+++ b/audiosprite.js
@@ -354,7 +354,7 @@ function processFiles() {
       }
 
       json.resources = json.resources.map(function(e) {
-        return argv.path + e
+        return argv.path ? path.join(argv.path, path.basename(e)) : e
       })
 
       var finalJson = {}


### PR DESCRIPTION
I have made a small tweak following @bassarisse's excellent updates. Previously, custom paths were only prepended to the resource URL, I have updated to use the specified path instead.

For example, audiospriting to an output file of `foo/sprite` with a path of `bar/` would result in a resource URL of `bar/foo/sprite`. With this update, the specified path is used fully, resulting in `bar/sprite`.

I bumped into this issue running audiosprite from my project root (as an npm script). I need the output json to reference my web path, but it instead includes the path from my project root.

I hope this makes sense. As I write it, it feels a little confusing, let me know if any clarification is required (:
