### PR TITLE
CLI and API separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ info: All done
 }
 ```
 
+###API Usage
+```js
+var audiosprite = require('audiosprite')
+
+var files = ['file1.mp3', 'file2.mp3']
+var opts = {output: 'result'}
+
+audiosprite(files, opts, function(err, obj) {
+  if (err) return console.error(err)
+
+  console.log(JSON.stringify(obj, null, 2))
+})
+```
+
 ####Setting autoplay track
 
 You can use `--autoplay` option to set a track that will start playing automatically. This track is then marked as autoplay and looping in the JSON. This syntax is Jukebox framework specific.
@@ -131,4 +145,3 @@ audio.play('click');
 ```
 
 *Don't forget to use the `--rawparts=mp3` option to benefit from the LimeJS feature to automatically switch to Web Audio API when it's supported by the client.*
-

--- a/audiosprite.js
+++ b/audiosprite.js
@@ -1,408 +1,324 @@
-#!/usr/bin/env node
-
 var fs = require('fs')
 var path = require('path')
 var async = require('async')
 var _ = require('underscore')._
-var winston = require('winston')
 
-var optimist = require('optimist')
-  .options('output', {
-    alias: 'o'
-  , 'default': 'output'
-  , describe: 'Name for the output files.'
-  })
-  .options('path', {
-    alias: 'u'
-  , 'default': ''
-  , describe: 'Path for files to be used on final JSON.'
-  })
-  .options('export', {
-    alias: 'e'
-  , 'default': 'ogg,m4a,mp3,ac3'
-  , describe: 'Limit exported file types. Comma separated extension list.'
-  })
-  .options('format', {
-    alias: 'f'
-  , 'default': 'jukebox'
-  , describe: 'Format of the output JSON file (jukebox, howler, createjs).'
-  })
-  .options('log', {
-    alias: 'l'
-  , 'default': 'info'
-  , describe: 'Log level (debug, info, notice, warning, error).'
-  })
-  .options('autoplay', {
-    alias: 'a'
-  , 'default': null
-  , describe: 'Autoplay sprite name.'
-  })
-  .options('loop', {
-    'default': null
-  , describe: 'Loop sprite name, can be passed multiple times.'
-  })
-  .options('silence', {
-    alias: 's'
-  , 'default': 0
-  , describe: 'Add special "silence" track with specified duration.'
-  })
-  .options('gap', {
-    alias: 'g'
-  , 'default': 1
-  , describe: 'Silence gap between sounds (in seconds).'
-  })
-  .options('minlength', {
-    alias: 'm'
-  , 'default': 0
-  , describe: 'Minimum sound duration (in seconds).'
-  })
-  .options('bitrate', {
-    alias: 'b'
-  , 'default': 128
-  , describe: 'Bit rate. Works for: ac3, mp3, mp4, m4a, ogg.'
-  })
-  .options('vbr', {
-    alias: 'v'
-  , 'default': -1
-  , describe: 'VBR [0-9]. Works for: mp3. -1 disables VBR.'
-  })
-  .options('samplerate', {
-    alias: 'r'
-  , 'default': 44100
-  , describe: 'Sample rate.'
-  })
-  .options('channels', {
-    alias: 'c'
-  , 'default': 1
-  , describe: 'Number of channels (1=mono, 2=stereo).'
-  })
-  .options('rawparts', {
-    alias: 'p'
-  , 'default': ''
-  , describe: 'Include raw slices(for Web Audio API) in specified formats.'
-  })
-  .options('help', {
-    alias: 'h'
-  , describe: 'Show this help message.'
-  })
-
-var argv = optimist.argv
-
-winston.remove(winston.transports.Console)
-winston.add(winston.transports.Console, {
-  colorize: true
-, level: argv.log
-, handleExceptions: false
-})
-winston.debug('Parsed arguments', argv)
-
-
-var BIT_RATE = parseInt(argv.bitrate, 10)
-var SAMPLE_RATE = parseInt(argv.samplerate, 10)
-var NUM_CHANNELS = parseInt(argv.channels, 10)
-var GAP_SECONDS = parseFloat(argv.gap)
-var MINIMUM_SOUND_LENGTH = parseFloat(argv.minlength)
-var VBR = parseInt(argv.vbr, 10)
-
-var loops = argv.loop ? [].concat(argv.loop) : []
-
-var files = _.uniq(argv._)
-
-if (argv.help || !files.length) {
-  if (!argv.help) {
-    winston.error('No input files specified.')
+var defaults = {
+  output: 'output',
+  path: '',
+  export: 'ogg,m4a,mp3,ac3',
+  format: null,
+  autoplay: null,
+  loop: [],
+  silence: 0,
+  gap: 1,
+  minlength: 0,
+  bitrate: 128,
+  vbr: -1,
+  samplerate: 44100,
+  channels: 1,
+  rawparts: '',
+  logger: {
+    debug: function(){},
+    info: function(){},
+    log: function(){}
   }
-  winston.info('Usage: audiosprite [options] file1.mp3 file2.mp3 *.wav')
-  winston.info(optimist.help())
-  process.exit(1)
 }
 
-// make sure output directory exists
-var outputDir = path.dirname(argv.output)
-if (!fs.existsSync(outputDir)) {
-  require('mkdirp').sync(outputDir)
-}
+module.exports = function(files) {
+  var opts = {}, callback = function(){}
 
-var offsetCursor = 0
-var wavArgs = ['-ar', SAMPLE_RATE, '-ac', NUM_CHANNELS, '-f', 's16le']
-var tempFile = mktemp('audiosprite')
+  if (!files || !files.length) return callback(new Error('No input files specified.'))
 
-winston.debug('Created temporary file', { file: tempFile })
-
-var json = {
-  resources: []
-, spritemap: {}
-}
-
-spawn('ffmpeg', ['-version']).on('exit', function(code) {
-  if (code) {
-    winston.error('ffmpeg was not found on your path')
-    process.exit(1)
+  if (arguments.length == 2) {
+    callback = arguments[1]
+  } else if (arguments.length >= 3) {
+    opts = arguments[1]
+    callback = arguments[2]
   }
-  if (argv.silence) {
-    json.spritemap.silence = {
-      start: 0
-    , end: argv.silence
-    , loop: true
+
+  opts = _.extend(defaults, opts)
+
+  // make sure output directory exists
+  var outputDir = path.dirname(opts.output)
+  if (!fs.existsSync(outputDir)) {
+    require('mkdirp').sync(outputDir)
+  }
+
+  var offsetCursor = 0
+  var wavArgs = ['-ar', opts.samplerate, '-ac', opts.channels, '-f', 's16le']
+  var tempFile = mktemp('audiosprite')
+
+  opts.logger.debug('Created temporary file', { file: tempFile })
+
+  var json = {
+    resources: []
+  , spritemap: {}
+  }
+
+  spawn('ffmpeg', ['-version']).on('exit', function(code) {
+    if (code) {
+      callback(new Error('ffmpeg was not found on your path'))
     }
-    if (!argv.autoplay) {
-      json.autoplay = 'silence'
+    if (opts.silence) {
+      json.spritemap.silence = {
+        start: 0
+      , end: opts.silence
+      , loop: true
+      }
+      if (!opts.autoplay) {
+        json.autoplay = 'silence'
+      }
+      appendSilence(opts.silence + opts.gap, tempFile, processFiles)
+    } else {
+      processFiles()
     }
-    appendSilence(argv.silence + GAP_SECONDS, tempFile, processFiles)
-  } else {
-    processFiles()
+  })
+
+  function mktemp(prefix) {
+    var tmpdir = require('os').tmpDir() || '.'
+    return path.join(tmpdir, prefix + '.' + Math.random().toString().substr(2))
   }
-})
 
-
-function mktemp(prefix) {
-  var tmpdir = require('os').tmpDir() || '.'
-  return path.join(tmpdir, prefix + '.' + Math.random().toString().substr(2))
-}
-
-function spawn(name, opt) {
-  winston.debug('Spawn', { cmd: [name].concat(opt).join(' ') })
-  return require('child_process').spawn(name, opt)
-}
-
-function pad(num, size) {
-  var str = num.toString()
-  while (str.length < size) {
-    str = '0' + str
+  function spawn(name, opt) {
+    opts.logger.debug('Spawn', { cmd: [name].concat(opt).join(' ') })
+    return require('child_process').spawn(name, opt)
   }
-  return str
-}
 
-function makeRawAudioFile(src, cb) {
-  var dest = mktemp('audiosprite')
+  function pad(num, size) {
+    var str = num.toString()
+    while (str.length < size) {
+      str = '0' + str
+    }
+    return str
+  }
 
-  winston.debug('Start processing', { file: src})
+  function makeRawAudioFile(src, cb) {
+    var dest = mktemp('audiosprite')
 
-  fs.exists(src, function(exists) {
-    if (exists) {
-      var ffmpeg = spawn('ffmpeg', ['-i', path.resolve(src)]
-        .concat(wavArgs).concat('pipe:'))
-      ffmpeg.stdout.pipe(fs.createWriteStream(dest, {flags: 'w'}))
-      ffmpeg.on('exit', function(code, signal) {
+    opts.logger.debug('Start processing', { file: src})
+
+    fs.exists(src, function(exists) {
+      if (exists) {
+        var ffmpeg = spawn('ffmpeg', ['-i', path.resolve(src)]
+          .concat(wavArgs).concat('pipe:'))
+        ffmpeg.stdout.pipe(fs.createWriteStream(dest, {flags: 'w'}))
+        ffmpeg.on('exit', function(code, signal) {
+          if (code) {
+            return cb({
+              msg: 'File could not be added',
+              file: src,
+              retcode: code,
+              signal: signal
+            })
+          }
+          cb(null, dest)
+        })
+      }
+      else {
+        cb({ msg: 'File does not exist', file: src })
+      }
+    })
+  }
+
+  function appendFile(name, src, dest, cb) {
+    var size = 0
+    var reader = fs.createReadStream(src)
+    var writer = fs.createWriteStream(dest, {
+      flags: 'a'
+    })
+    reader.on('data', function(data) {
+      size += data.length
+    })
+    reader.on('close', function() {
+      var originalDuration = size / opts.samplerate / opts.channels / 2
+      opts.logger.info('File added OK', { file: src, duration: originalDuration })
+      var extraDuration = Math.max(0, opts.minlength - originalDuration)
+      var duration = originalDuration + extraDuration
+      json.spritemap[name] = {
+        start: offsetCursor
+      , end: offsetCursor + duration
+      , loop: name === opts.autoplay || opts.loop.indexOf(name) !== -1
+      }
+      offsetCursor += originalDuration
+      appendSilence(extraDuration + Math.ceil(duration) - duration + opts.gap, dest, cb)
+    })
+    reader.pipe(writer)
+  }
+
+  function appendSilence(duration, dest, cb) {
+    var buffer = new Buffer(Math.round(opts.samplerate * 2 * opts.channels * duration))
+    buffer.fill(0)
+    var writeStream = fs.createWriteStream(dest, { flags: 'a' })
+    writeStream.end(buffer)
+    writeStream.on('close', function() {
+      opts.logger.info('Silence gap added', { duration: duration })
+      offsetCursor += duration
+      cb()
+    })
+  }
+
+  function exportFile(src, dest, ext, opt, store, cb) {
+    var outfile = dest + '.' + ext
+    spawn('ffmpeg',['-y', '-ar', opts.samplerate, '-ac', opts.channels, '-f', 's16le', '-i', src]
+        .concat(opt).concat(outfile))
+      .on('exit', function(code, signal) {
         if (code) {
           return cb({
-            msg: 'File could not be added',
-            file: src,
+            msg: 'Error exporting file',
+            format: ext,
             retcode: code,
             signal: signal
           })
         }
-        cb(null, dest)
+        if (ext === 'aiff') {
+          exportFileCaf(outfile, dest + '.caf', function(err) {
+            if (!err && store) {
+              json.resources.push(dest + '.caf')
+            }
+            fs.unlinkSync(outfile)
+            cb()
+          })
+        } else {
+          opts.logger.info('Exported ' + ext + ' OK', { file: outfile })
+          if (store) {
+            json.resources.push(outfile)
+          }
+          cb()
+        }
       })
+  }
+
+  function exportFileCaf(src, dest, cb) {
+    if (process.platform !== 'darwin') {
+      return cb(true)
+    }
+    spawn('afconvert', ['-f', 'caff', '-d', 'ima4', src, dest])
+      .on('exit', function(code, signal) {
+        if (code) {
+          return cb({
+            msg: 'Error exporting file',
+            format: 'caf',
+            retcode: code,
+            signal: signal
+          })
+        }
+        opts.logger.info('Exported caf OK', { file: dest })
+        return cb()
+      })
+  }
+
+  function processFiles() {
+    var formats = {
+      aiff: []
+    , wav: []
+    , ac3: ['-acodec', 'ac3', '-ab', opts.bitrate + 'k']
+    , mp3: ['-ar', opts.samplerate, '-f', 'mp3']
+    , mp4: ['-ab', opts.bitrate + 'k']
+    , m4a: ['-ab', opts.bitrate + 'k']
+    , ogg: ['-acodec', 'libvorbis', '-f', 'ogg', '-ab', opts.bitrate + 'k']
+    }
+
+    if (opts.vbr >= 0 && opts.vbr <= 9) {
+      formats.mp3 = formats.mp3.concat(['-aq', opts.vbr])
     }
     else {
-      cb({ msg: 'File does not exist', file: src })
+      formats.mp3 = formats.mp3.concat(['-ab', opts.bitrate + 'k'])
     }
-  })
-}
 
-function appendFile(name, src, dest, cb) {
-  var size = 0
-  var reader = fs.createReadStream(src)
-  var writer = fs.createWriteStream(dest, {
-    flags: 'a'
-  })
-  reader.on('data', function(data) {
-    size += data.length
-  })
-  reader.on('close', function() {
-    var originalDuration = size / SAMPLE_RATE / NUM_CHANNELS / 2
-    winston.info('File added OK', { file: src, duration: originalDuration })
-    var extraDuration = Math.max(0, MINIMUM_SOUND_LENGTH - originalDuration)
-    var duration = originalDuration + extraDuration
-    json.spritemap[name] = {
-      start: offsetCursor
-    , end: offsetCursor + duration
-    , loop: name === argv.autoplay || loops.indexOf(name) !== -1
+    if (opts.export.length) {
+      formats = opts.export.split(',').reduce(function(memo, val) {
+        if (formats[val]) {
+          memo[val] = formats[val]
+        }
+        return memo
+      }, {})
     }
-    offsetCursor += originalDuration
-    appendSilence(extraDuration + Math.ceil(duration) - duration + GAP_SECONDS, dest, cb)
-  })
-  reader.pipe(writer)
-}
 
-function appendSilence(duration, dest, cb) {
-  var buffer = new Buffer(Math.round(SAMPLE_RATE * 2 * NUM_CHANNELS * duration))
-  buffer.fill(0)
-  var writeStream = fs.createWriteStream(dest, { flags: 'a' })
-  writeStream.end(buffer)
-  writeStream.on('close', function() {
-    winston.info('Silence gap added', { duration: duration })
-    offsetCursor += duration
-    cb()
-  })
-}
+    var rawparts = opts.rawparts.length ? opts.rawparts.split(',') : null
+    var i = 0
+    async.forEachSeries(files, function(file, cb) {
+      i++
+      makeRawAudioFile(file, function(err, tmp) {
+        if (err) {
+          return cb(err)
+        }
 
-function exportFile(src, dest, ext, opt, store, cb) {
-  var outfile = dest + '.' + ext
-  spawn('ffmpeg',['-y', '-ar', SAMPLE_RATE, '-ac', NUM_CHANNELS, '-f', 's16le', '-i', src]
-      .concat(opt).concat(outfile))
-    .on('exit', function(code, signal) {
-      if (code) {
-        return cb({
-          msg: 'Error exporting file',
-          format: ext,
-          retcode: code,
-          signal: signal
-        })
-      }
-      if (ext === 'aiff') {
-        exportFileCaf(outfile, dest + '.caf', function(err) {
-          if (!err && store) {
-            json.resources.push(dest + '.caf')
-          }
-          fs.unlinkSync(outfile)
+        function tempProcessed() {
+          fs.unlinkSync(tmp)
           cb()
-        })
-      } else {
-        winston.info('Exported ' + ext + ' OK', { file: outfile })
-        if (store) {
-          json.resources.push(outfile)
         }
-        cb()
-      }
-    })
-}
 
-function exportFileCaf(src, dest, cb) {
-  if (process.platform !== 'darwin') {
-    return cb(true)
-  }
-  spawn('afconvert', ['-f', 'caff', '-d', 'ima4', src, dest])
-    .on('exit', function(code, signal) {
-      if (code) {
-        return cb({
-          msg: 'Error exporting file',
-          format: 'caf',
-          retcode: code,
-          signal: signal
+        var name = path.basename(file).replace(/\.[a-zA-Z0-9]+$/, '')
+        appendFile(name, tmp, tempFile, function(err) {
+          if (rawparts != null ? rawparts.length : void 0) {
+          async.forEachSeries(rawparts, function(ext, cb) {
+            opts.logger.debug('Start export slice', { name: name, format: ext, i: i })
+            exportFile(tmp, opts.output + '_' + pad(i, 3), ext, formats[ext]
+              , false, cb)
+            }, tempProcessed)
+          } else {
+            tempProcessed()
+          }
         })
-      }
-      winston.info('Exported caf OK', { file: dest })
-      return cb()
-    })
-}
-
-function processFiles() {
-  var formats = {
-    aiff: []
-  , wav: []
-  , ac3: ['-acodec', 'ac3', '-ab', BIT_RATE + 'k']
-  , mp3: ['-ar', SAMPLE_RATE, '-f', 'mp3']
-  , mp4: ['-ab', BIT_RATE + 'k']
-  , m4a: ['-ab', BIT_RATE + 'k']
-  , ogg: ['-acodec', 'libvorbis', '-f', 'ogg', '-ab', BIT_RATE + 'k']
-  }
-
-  if (VBR >= 0 && VBR <= 9) {
-    formats.mp3 = formats.mp3.concat(['-aq', VBR])
-  }
-  else {
-    formats.mp3 = formats.mp3.concat(['-ab', BIT_RATE + 'k'])
-  }
-
-  if (argv.export.length) {
-    formats = argv.export.split(',').reduce(function(memo, val) {
-      if (formats[val]) {
-        memo[val] = formats[val]
-      }
-      return memo
-    }, {})
-  }
-
-  var rawparts = argv.rawparts.length ? argv.rawparts.split(',') : null
-  var i = 0
-  async.forEachSeries(files, function(file, cb) {
-    i++
-    makeRawAudioFile(file, function(err, tmp) {
-      if (err) {
-        return cb(err)
-      }
-
-      function tempProcessed() {
-        fs.unlinkSync(tmp)
-        cb()
-      }
-
-      var name = path.basename(file).replace(/\.[a-zA-Z0-9]+$/, '')
-      appendFile(name, tmp, tempFile, function(err) {
-        if (rawparts != null ? rawparts.length : void 0) {
-        async.forEachSeries(rawparts, function(ext, cb) {
-          winston.debug('Start export slice', { name: name, format: ext, i: i })
-          exportFile(tmp, argv.output + '_' + pad(i, 3), ext, formats[ext]
-            , false, cb)
-          }, tempProcessed)
-        } else {
-          tempProcessed()
-        }
       })
-    })
-  }, function(err) {
-    if (err) {
-      winston.error('Error adding file', err)
-      process.exit(1)
-    }
-    async.forEachSeries(Object.keys(formats), function(ext, cb) {
-      winston.debug('Start export', { format: ext })
-      exportFile(tempFile, argv.output, ext, formats[ext], true, cb)
     }, function(err) {
       if (err) {
-        winston.error('Error exporting file', err)
-        process.exit(1)
+        return callback(new Error('Error adding file'))
       }
-      if (argv.autoplay) {
-        json.autoplay = argv.autoplay
-      }
+      async.forEachSeries(Object.keys(formats), function(ext, cb) {
+        opts.logger.debug('Start export', { format: ext })
+        exportFile(tempFile, opts.output, ext, formats[ext], true, cb)
+      }, function(err) {
+        if (err) {
+          return callback(new Error('Error exporting file'))
+        }
+        if (opts.autoplay) {
+          json.autoplay = opts.autoplay
+        }
 
-      json.resources = json.resources.map(function(e) {
-        return argv.path ? path.join(argv.path, path.basename(e)) : e
-      })
+        json.resources = json.resources.map(function(e) {
+          return opts.path ? path.join(opts.path, path.basename(e)) : e
+        })
 
-      var finalJson = {}
+        var finalJson = {}
 
-      switch (argv.format) {
+        switch (opts.format) {
 
-        case 'howler':
-          finalJson.urls = [].concat(json.resources)
-          finalJson.sprite = {}
-          for (var sn in json.spritemap) {
-            var spriteInfo = json.spritemap[sn]
-            finalJson.sprite[sn] = [spriteInfo.start * 1000, (spriteInfo.end - spriteInfo.start) * 1000]
-            if (spriteInfo.loop) {
-              finalJson.sprite[sn].push(true)
+          case 'howler':
+            finalJson.urls = [].concat(json.resources)
+            finalJson.sprite = {}
+            for (var sn in json.spritemap) {
+              var spriteInfo = json.spritemap[sn]
+              finalJson.sprite[sn] = [spriteInfo.start * 1000, (spriteInfo.end - spriteInfo.start) * 1000]
+              if (spriteInfo.loop) {
+                finalJson.sprite[sn].push(true)
+              }
             }
-          }
-          break
+            break
 
-        case 'createjs':
-          finalJson.src = json.resources[0]
-          finalJson.data = {audioSprite: []}
-          for (var sn in json.spritemap) {
-            var spriteInfo = json.spritemap[sn]
-            finalJson.data.audioSprite.push({
-              id: sn,
-              startTime: spriteInfo.start * 1000,
-              duration: (spriteInfo.end - spriteInfo.start) * 1000
-            })
-          }
-          break
+          case 'createjs':
+            finalJson.src = json.resources[0]
+            finalJson.data = {audioSprite: []}
+            for (var sn in json.spritemap) {
+              var spriteInfo = json.spritemap[sn]
+              finalJson.data.audioSprite.push({
+                id: sn,
+                startTime: spriteInfo.start * 1000,
+                duration: (spriteInfo.end - spriteInfo.start) * 1000
+              })
+            }
+            break
 
-        case 'default': // legacy support
-        default:
-          finalJson = json
-          break
-      }
+          case 'default': // legacy support
+          default:
+            finalJson = json
+            break
+        }
 
-      var jsonfile = argv.output + '.json'
-      fs.writeFileSync(jsonfile, JSON.stringify(finalJson, null, 2))
-      winston.info('Exported json OK', { file: jsonfile })
-      fs.unlinkSync(tempFile)
-      winston.info('All done')
+        fs.unlinkSync(tempFile)
+        callback(null, finalJson)
+      })
     })
-  })
+  }
 }

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+var fs = require('fs')
+var _ = require('underscore')._
+var winston = require('winston')
+
+var audiosprite = require('./audiosprite')
+
+var optimist = require('optimist')
+  .options('output', {
+    alias: 'o'
+  , 'default': 'output'
+  , describe: 'Name for the output files.'
+  })
+  .options('path', {
+    alias: 'u'
+  , 'default': ''
+  , describe: 'Path for files to be used on final JSON.'
+  })
+  .options('export', {
+    alias: 'e'
+  , 'default': 'ogg,m4a,mp3,ac3'
+  , describe: 'Limit exported file types. Comma separated extension list.'
+  })
+  .options('format', {
+    alias: 'f'
+  , 'default': 'jukebox'
+  , describe: 'Format of the output JSON file (jukebox, howler, createjs).'
+  })
+  .options('log', {
+    alias: 'l'
+  , 'default': 'info'
+  , describe: 'Log level (debug, info, notice, warning, error).'
+  })
+  .options('autoplay', {
+    alias: 'a'
+  , 'default': null
+  , describe: 'Autoplay sprite name.'
+  })
+  .options('loop', {
+    'default': null
+  , describe: 'Loop sprite name, can be passed multiple times.'
+  })
+  .options('silence', {
+    alias: 's'
+  , 'default': 0
+  , describe: 'Add special "silence" track with specified duration.'
+  })
+  .options('gap', {
+    alias: 'g'
+  , 'default': 1
+  , describe: 'Silence gap between sounds (in seconds).'
+  })
+  .options('minlength', {
+    alias: 'm'
+  , 'default': 0
+  , describe: 'Minimum sound duration (in seconds).'
+  })
+  .options('bitrate', {
+    alias: 'b'
+  , 'default': 128
+  , describe: 'Bit rate. Works for: ac3, mp3, mp4, m4a, ogg.'
+  })
+  .options('vbr', {
+    alias: 'v'
+  , 'default': -1
+  , describe: 'VBR [0-9]. Works for: mp3. -1 disables VBR.'
+  })
+  .options('samplerate', {
+    alias: 'r'
+  , 'default': 44100
+  , describe: 'Sample rate.'
+  })
+  .options('channels', {
+    alias: 'c'
+  , 'default': 1
+  , describe: 'Number of channels (1=mono, 2=stereo).'
+  })
+  .options('rawparts', {
+    alias: 'p'
+  , 'default': ''
+  , describe: 'Include raw slices(for Web Audio API) in specified formats.'
+  })
+  .options('help', {
+    alias: 'h'
+  , describe: 'Show this help message.'
+  })
+
+var argv = optimist.argv
+var opts = _.extend({}, argv)
+
+winston.remove(winston.transports.Console)
+winston.add(winston.transports.Console, {
+  colorize: true
+, level: argv.log
+, handleExceptions: false
+})
+winston.debug('Parsed arguments', argv)
+
+opts.logger = winston
+
+opts.bitrate = parseInt(argv.bitrate, 10)
+opts.samplerate = parseInt(argv.samplerate, 10)
+opts.channels = parseInt(argv.channels, 10)
+opts.gap = parseFloat(argv.gap)
+opts.minlength = parseFloat(argv.minlength)
+opts.vbr = parseInt(argv.vbr, 10)
+
+opts.loop = argv.loop ? [].concat(argv.loop) : []
+
+var files = _.uniq(argv._)
+
+if (argv.help || !files.length) {
+  if (!argv.help) {
+    winston.error('No input files specified.')
+  }
+  winston.info('Usage: audiosprite [options] file1.mp3 file2.mp3 *.wav')
+  winston.info(optimist.help())
+  process.exit(1)
+}
+
+audiosprite(files, opts, function(err, obj) {
+  if (err) {
+    winston.error(err)
+    process.exit(0)
+  }
+  var jsonfile = opts.output + '.json'
+  fs.writeFileSync(jsonfile, JSON.stringify(obj, null, 2))
+  winston.info('Exported json OK', { file: jsonfile })
+  winston.info('All done')
+})

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "main": "./audiosprite.js",
   "bin": {
-    "audiosprite": "./audiosprite.js"
+    "audiosprite": "./cli.js"
   },
   "dependencies": {
     "async": "~0.2.10",

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ var assert = require('assert')
   , path = require('path')
   , spawn = require('child_process').spawn
 
-var AUDIOSPRITE_PATH = path.join(__dirname, '../')
+var AUDIOSPRITE_PATH = path.join(__dirname, '../', 'cli.js')
   , OUTPUT = 'audiosprite-test-out' + ~~(Math.random() * 1e6)
 
 var tmpdir = require('os').tmpDir() || '.'


### PR DESCRIPTION
Basically the same thing, split in two files and wrapping most of it in a `module.exports` function. This way we can batch process sprites creation from node, without having to spawn audiosprite itself, also making easier to write things like a gulp plugin.

I ain't proud of wrapping everything in a function, but I wanted to change it slightly as possible.