### PR TITLE
Update audiosprite.js

### DIFF
--- a/audiosprite.js
+++ b/audiosprite.js
@@ -215,7 +215,7 @@ module.exports = function(files) {
     , ac3: ['-acodec', 'ac3', '-ab', opts.bitrate + 'k']
     , mp3: ['-ar', opts.samplerate, '-f', 'mp3']
     , mp4: ['-ab', opts.bitrate + 'k']
-    , m4a: ['-ab', opts.bitrate + 'k']
+    , m4a: ['-ab', opts.bitrate + 'k', '-strict', '-2']
     , ogg: ['-acodec', 'libvorbis', '-f', 'ogg', '-ab', opts.bitrate + 'k']
     }
 


### PR DESCRIPTION
when trying to compile m4a ffmpeg gives error: "The encoder 'aac' is experimental but experimental codecs are not enabled, add '-strict -2' if you want to use it."

so I have added "-strict -2" to be used by default in m4a proccessing
