### PR TITLE
Wildcard support on Windows

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -110,6 +110,17 @@ opts.loop = argv.loop ? [].concat(argv.loop) : []
 
 var files = _.uniq(argv._)
 
+if (process.platform == 'win32') {
+  var glob = require('glob');
+  function flatten(arr){
+    return [].concat.apply([], arr);
+  }
+  function getNames(fname){
+	return (glob.hasMagic(fname)) ? glob.sync(fname) : [fname];
+  }
+  files = flatten(files.map(getNames));
+}
+
 if (argv.help || !files.length) {
   if (!argv.help) {
     winston.error('No input files specified.')

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "async": "~0.9.0",
+    "glob": "^6.0.4",
     "mkdirp": "^0.5.0",
     "optimist": "~0.6.1",
     "underscore": "~1.8.3",

--- a/test/test.js
+++ b/test/test.js
@@ -17,8 +17,8 @@ function cleanTmpDir() {
 }
 
 describe('audiosprite', function() {
-  before(cleanTmpDir)
-  after(cleanTmpDir)
+  beforeEach(cleanTmpDir)
+  afterEach(cleanTmpDir)
 
   it('generate audiosprite', function(done) {
     this.timeout(10000)
@@ -37,7 +37,30 @@ describe('audiosprite', function() {
       , path.join(__dirname, 'sounds/beep.mp3')
       , path.join(__dirname, 'sounds/boop.wav')
       ])
+	
+	checkOutput(audiosprite, done)
+  });
+  it('generate audiosprite from wildcard', function(done) {
+    this.timeout(10000)
 
+    process.chdir(tmpdir)
+
+    var audiosprite = spawn('node',
+      [ AUDIOSPRITE_PATH
+      , '--rawparts=mp3'
+      , '-o'
+      , OUTPUT
+      , '-l'
+      , 'debug'
+      , '--autoplay'
+      , 'boop'
+      , path.join(__dirname, 'sounds/*.mp3')
+      , path.join(__dirname, 'sounds/*.wav')
+      ])
+	
+	checkOutput(audiosprite, done)
+  });
+  function checkOutput(audiosprite, done) {
     var out = ''
     audiosprite.stdout.on('data', function(dt) {
       out += dt.toString('utf8')
@@ -108,6 +131,5 @@ describe('audiosprite', function() {
 
       done()
     })
-
-  });
+  }
 })


### PR DESCRIPTION
Currently audiosprite does not support wildcards (e.g. `*.mp3`) on Windows command line. There is an advice to "Use Git Bash instead of Command Line or Powershell" in the instructions.

This PR implements the use of `glob` module on Windows to fix wildcards in command line, removing the necessity to install Git Bash.

Tests included. MacOS/Linux remain unchaged.