### PR TITLE
implements #42 [req] add .webm support

### DIFF
--- a/audiosprite.js
+++ b/audiosprite.js
@@ -15,6 +15,7 @@ var defaults = {
   minlength: 0,
   bitrate: 128,
   vbr: -1,
+  'vbr:vorbis': -1,
   samplerate: 44100,
   channels: 1,
   rawparts: '',
@@ -217,7 +218,8 @@ module.exports = function(files) {
     , mp4: ['-ab', opts.bitrate + 'k']
     , m4a: ['-ab', opts.bitrate + 'k']
     , ogg: ['-acodec', 'libvorbis', '-f', 'ogg', '-ab', opts.bitrate + 'k']
-    }
+    , webm: ['-acodec',  'libvorbis', '-f', 'webm']
+    };
 
     if (opts.vbr >= 0 && opts.vbr <= 9) {
       formats.mp3 = formats.mp3.concat(['-aq', opts.vbr])
@@ -225,6 +227,15 @@ module.exports = function(files) {
     else {
       formats.mp3 = formats.mp3.concat(['-ab', opts.bitrate + 'k'])
     }
+
+    // change quality of webm output - https://trac.ffmpeg.org/wiki/TheoraVorbisEncodingGuide
+    if (opts['vbr:vorbis'] >= 0 && opts['vbr:vorbis'] <= 10) {
+      formats.webm = formats.webm.concat(['-qscale:a', opts['vbr:vorbis']])
+    }
+    else {
+      formats.webm = formats.webm.concat(['-ab', opts.bitrate + 'k'])
+    }
+
 
     if (opts.export.length) {
       formats = opts.export.split(',').reduce(function(memo, val) {

--- a/cli.js
+++ b/cli.js
@@ -66,6 +66,11 @@ var optimist = require('optimist')
   , 'default': -1
   , describe: 'VBR [0-9]. Works for: mp3. -1 disables VBR.'
   })
+  .options('vbr:vorbis', {
+    alias: 'q'
+    , 'default': -1
+    , describe: 'qscale [0-10 is highest quality]. Works for: webm. -1 disables qscale.'
+  })
   .options('samplerate', {
     alias: 'r'
   , 'default': 44100
@@ -105,6 +110,7 @@ opts.channels = parseInt(argv.channels, 10)
 opts.gap = parseFloat(argv.gap)
 opts.minlength = parseFloat(argv.minlength)
 opts.vbr = parseInt(argv.vbr, 10)
+opts['vbr:vorbis'] = parseInt(argv['vbr:vorbis'], 10)
 
 opts.loop = argv.loop ? [].concat(argv.loop) : []
 


### PR DESCRIPTION
this pull request closes issue #42

because VBR values for [mp3](https://trac.ffmpeg.org/wiki/Encode/MP3) and [vorbis](https://trac.ffmpeg.org/wiki/TheoraVorbisEncodingGuide) differ I added optional parameter `vbr:vorbis`