### PR TITLE
add "opus" audio format

### DIFF
--- a/audiosprite.js
+++ b/audiosprite.js
@@ -218,6 +218,7 @@ module.exports = function(files) {
     , mp4: ['-ab', opts.bitrate + 'k']
     , m4a: ['-ab', opts.bitrate + 'k']
     , ogg: ['-acodec', 'libvorbis', '-f', 'ogg', '-ab', opts.bitrate + 'k']
+    , opus: ['-acodec', 'libopus', '-ab', opts.bitrate + 'k']
     , webm: ['-acodec',  'libvorbis', '-f', 'webm']
     };
 


### PR DESCRIPTION
More info about opus:

> Opus is a totally open, royalty-free, highly versatile audio codec. Opus is unmatched for interactive speech and music transmission over the Internet, but is also intended for storage and streaming applications. It is standardized by the Internet Engineering Task Force (IETF) as RFC 6716 which incorporated technology from Skype's SILK codec and Xiph.Org's CELT codec. - Source: https://www.opus-codec.org/
- Current browser support: http://caniuse.com/#feat=opus
- Audio test checking for Opus support: http://hpr.dogphilosophy.net/test/
