### PR TITLE
Fix: os.tmpDir() is deprecated in Node v7+

### DIFF
--- a/audiosprite.js
+++ b/audiosprite.js
@@ -77,7 +77,7 @@ module.exports = function(files) {
   })
 
   function mktemp(prefix) {
-    var tmpdir = require('os').tmpDir() || '.'
+    var tmpdir = require('os').tmpdir() || '.'
     return path.join(tmpdir, prefix + '.' + Math.random().toString().substr(2))
   }
 


### PR DESCRIPTION
`os.tmpDir()` is deprecated in Node v7+. Use `os.tmpdir()` instead.