### PR TITLE
use dash flag with webm

### DIFF
--- a/audiosprite.js
+++ b/audiosprite.js
@@ -231,7 +231,7 @@ module.exports = function(files) {
     , m4a: ['-ab', opts.bitrate + 'k', '-strict', '-2']
     , ogg: ['-acodec', 'libvorbis', '-f', 'ogg', '-ab', opts.bitrate + 'k']
     , opus: ['-acodec', 'libopus', '-ab', opts.bitrate + 'k']
-    , webm: ['-acodec',  'libvorbis', '-f', 'webm']
+    , webm: ['-acodec',  'libvorbis', '-f', 'webm', '-dash', '1']
     };
     
     if (opts.vbr >= 0 && opts.vbr <= 9) {


### PR DESCRIPTION
Per Howler.js [format recommendations](https://github.com/goldfire/howler.js#documentation), adding `dash` flag to WebM output configuration in order to encode WebM files with cues element for optimal seekability in Firefox.