### PR TITLE
Added ability to bypass whole second rounding for silence gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,22 +40,23 @@ brew install ffmpeg --with-theora --with-libvorbis
 > audiosprite --help
 info: Usage: audiosprite [options] file1.mp3 file2.mp3 *.wav
 info: Options:
-  --output, -o      Name for the output files.                                   [default: "output"]
-  --path, -u        Path for files to be used on final JSON.                     [default: ""]
-  --export, -e      Limit exported file types. Comma separated extension list.   [default: "ogg,m4a,mp3,ac3"]
-  --format, -f      Format of the output JSON file (jukebox, howler, createjs).  [default: "jukebox"]
-  --log, -l         Log level (debug, info, notice, warning, error).             [default: "info"]
-  --autoplay, -a    Autoplay sprite name.                                        [default: null]
-  --loop            Loop sprite name, can be passed multiple times.              [default: null]
-  --silence, -s     Add special "silence" track with specified duration.         [default: 0]
-  --gap, -g         Silence gap between sounds (in seconds).                     [default: 1]
-  --minlength, -m   Minimum sound duration (in seconds).                         [default: 0]
-  --bitrate, -b     Bit rate. Works for: ac3, mp3, mp4, m4a, ogg.                [default: 128]
-  --vbr, -v         VBR [0-9]. Works for: mp3. -1 disables VBR.                  [default: -1]
-  --samplerate, -r  Sample rate.                                                 [default: 44100]
-  --channels, -c    Number of channels (1=mono, 2=stereo).                       [default: 1]
-  --rawparts, -p    Include raw slices(for Web Audio API) in specified formats.  [default: ""]
-  --help, -h        Show this help message.
+  --output, -o          Name for the output files.                                               [default: "output"]
+  --path, -u            Path for files to be used on final JSON.                                 [default: ""]
+  --export, -e          Limit exported file types. Comma separated extension list.               [default: "ogg,m4a,mp3,ac3"]
+  --format, -f          Format of the output JSON file (jukebox, howler, createjs).              [default: "jukebox"]
+  --log, -l             Log level (debug, info, notice, warning, error).                         [default: "info"]
+  --autoplay, -a        Autoplay sprite name.                                                    [default: null]
+  --loop                Loop sprite name, can be passed multiple times.                          [default: null]
+  --silence, -s         Add special "silence" track with specified duration.                     [default: 0]
+  --gap, -g             Silence gap between sounds (in seconds).                                 [default: 1]
+  --minlength, -m       Minimum sound duration (in seconds).                                     [default: 0]
+  --bitrate, -b         Bit rate. Works for: ac3, mp3, mp4, m4a, ogg.                            [default: 128]
+  --vbr, -v             VBR [0-9]. Works for: mp3. -1 disables VBR.                              [default: -1]
+  --samplerate, -r      Sample rate.                                                             [default: 44100]
+  --channels, -c        Number of channels (1=mono, 2=stereo).                                   [default: 1]
+  --rawparts, -p        Include raw slices(for Web Audio API) in specified formats.              [default: ""]
+  --ignorerounding, -i  Bypass sound placement on whole second boundaries (0=round,1=bypass).    [default: 0]
+  --help, -h            Show this help message.
 
 
 > audiosprite --autoplay bg_loop --output mygameaudio bg_loop.wav *.mp3

--- a/audiosprite.js
+++ b/audiosprite.js
@@ -20,6 +20,7 @@ const defaults = {
   samplerate: 44100,
   channels: 1,
   rawparts: '',
+  ignorerounding: 0,
   logger: {
     debug: function(){},
     info: function(){},
@@ -152,7 +153,16 @@ module.exports = function(files) {
         , loop: name === opts.autoplay || opts.loop.indexOf(name) !== -1
       }
       offsetCursor += originalDuration
-      appendSilence(extraDuration + Math.ceil(duration) - duration + opts.gap, dest, cb)
+
+      var delta = Math.ceil(duration) - duration;
+
+      if (opts.ignorerounding)
+      {
+        opts.logger.info('Ignoring nearest second silence gap rounding');
+        delta = 0;
+      }
+
+      appendSilence(extraDuration + delta + opts.gap, dest, cb)
     })
     reader.pipe(writer)
   }

--- a/cli.js
+++ b/cli.js
@@ -86,6 +86,11 @@ var optimist = require('optimist')
   , 'default': ''
   , describe: 'Include raw slices(for Web Audio API) in specified formats.'
   })
+  .options('ignorerounding', {
+    alias: 'i'
+  , 'default': 0
+  , describe: 'Bypass sound placement on whole second boundaries (0=round,1=bypass).'
+  })
   .options('help', {
     alias: 'h'
   , describe: 'Show this help message.'
@@ -113,6 +118,8 @@ opts.vbr = parseInt(argv.vbr, 10)
 opts['vbr:vorbis'] = parseInt(argv['vbr:vorbis'], 10)
 
 opts.loop = argv.loop ? [].concat(argv.loop) : []
+
+opts.ignorerounding = parseInt(argv.ignorerounding, 0)
 
 var files = _.uniq(argv._)
 


### PR DESCRIPTION
Introduced to minimise the run-time memory cost of silence for atlases with appreciable numbers of members for certain platforms and contexts where memory pressure may be high. Passing '--ignorerounding=1' will eliminate the extra silence gap introduced by rounding to the nearest second.