### PR TITLE
Allow generating audiosprites without a gap.

### DIFF
--- a/audiosprite.js
+++ b/audiosprite.js
@@ -159,6 +159,7 @@ module.exports = function(files) {
       if (opts.ignorerounding)
       {
         opts.logger.info('Ignoring nearest second silence gap rounding');
+        extraDuration = 0;
         delta = 0;
       }
 


### PR DESCRIPTION
Set extra duration to zero when ignoring rounding, this allows the user to generate an audiosprite without a gap. This fixes #52