### PR TITLE
Listen for ffmpeg 'close' event instead of 'exit'.

### DIFF
--- a/audiosprite.js
+++ b/audiosprite.js
@@ -115,7 +115,7 @@ module.exports = function(files) {
         let ffmpeg = spawn('ffmpeg', ['-i', path.resolve(src)]
           .concat(wavArgs).concat('pipe:'))
         ffmpeg.stdout.pipe(fs.createWriteStream(dest, {flags: 'w'}))
-        ffmpeg.on('exit', function(code, signal) {
+        ffmpeg.on('close', function(code, signal) {
           if (code) {
             return cb({
               msg: 'File could not be added',


### PR DESCRIPTION
Allows the ffmpeg process stdout stream (ie. the piped sample) to be fully processed always even if the system is under heavy load. Fixes #72 