### PR TITLE
Update brew install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install -g git+https://github.com/tonistiigi/audiosprite.git
 You can install `FFmpeg` and the `ogg` codecs on OSX using `brew`:
 
 ```
-brew install ffmpeg --with-theora --with-libvorbis
+brew install ffmpeg
 ```
 
 #### Hints for Windows users


### PR DESCRIPTION
According to this thread https://github.com/jiaaro/pydub/issues/575#issue-843132327 
brew install FFmpeg don't have to add `----with-theora --with-libvorbis` anymore.